### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from paddleocr import PaddleOCR
 use_angle_classifier = False
 model_path = './model/'
 
-ocr = PaddleOCR(lang='latin', show_log=False, det=True, 
+model = PaddleOCR(lang='latin', show_log=False, det=True, 
                use_angle_cls=use_angle_classifier,
                rec_model_dir=model_path, 
                use_gpu=True)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ onnx_rec_model = './onnx_model/rec_onnx/model.onnx'
 onnx_det_model = './onnx_model/det_onnx/model.onnx'
 onnx_cls_model = './onnx_model/cls_onnx/model.onnx'
 
-ocr = PaddleOCR(lang='latin', show_log=False, det=True, 
+model = PaddleOCR(lang='latin', show_log=False, det=True, 
                 use_angle_cls=use_angle_classifier,
                 rec_model_dir=onnx_rec_model, 
                 det_model_dir=onnx_det_model,


### PR DESCRIPTION
In the README.md the code examples that help you get started were not working. The problem seemed to be that the `PaddleOCR` instance was set to a variable named `ocr`, but we then call `res = model.ocr(...` instead of `res = ocr.ocr(...`. We suggest saving the `PaddleOCR` to the variable named `model` instead.